### PR TITLE
Add subcommand-based CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ All plots are saved in a user-defined output directory.
 
 ## Input files
 
-Below are the inputs for a complete visualization run:
+Below are the inputs for a visualization run:
 
 | Argument           | Description                           |
 |--------------------|---------------------------------------|
@@ -127,6 +127,56 @@ Optional:
 | --metadata_heatmap_new | Metadata for heatmap visualization    |
 | --amber                | CAMI Amber binning evaluation         |
 
+### Input files per subcommand
+
+#### sample-heatmap
+- `--coverm` (required)
+- `--gtdb` (required)
+- `--metadata` (optional)
+- `--meta_cols` (optional)
+
+#### comp-conta
+- `--checkm` (required)
+- `--checkm2` (required)
+- `--gtdb` (required for `--mode tax`)
+- `--metadata` + `--meta_col` (required for `--mode meta`)
+
+#### drep-cluster
+- `--drep` (required)
+- `--gtdb` (required)
+- `--checkm2`, `--quast`, `--bakta` (required for annotated heatmap)
+
+#### assembly-quality
+- `--quast` (required)
+- `--checkm2` (required)
+- `--gtdb` (required)
+
+#### bakta-annotation
+- `--bakta` (required)
+- `--checkm2` (required)
+
+#### taxa-sankey
+- `--gtdb` (required)
+
+
+## Command structure
+
+The command-line interface is organized into **subcommands**.
+Each subcommand generates exactly **one type of plot** and only shows the parameters relevant for that plot.
+
+```bash
+mags-visualization <subcommand> [OPTIONS]
+```
+
+Available subcommands:
+- sample-heatmap - MAG detection heatmap per sample
+- drep-cluster -dRep cluster visualization
+- comp-conta - completeness/contamination plots
+- taxa-sankey - GTDB taxonomy sankey plots
+- assembly-quality - QUAST-based assembly quality plots
+- bakta-annotation - Bakta annontation plots
+- all - legacy mode (runs multiple plots in one command)
+
 ## Command-Line usage
 
 ### Show help
@@ -134,23 +184,26 @@ Optional:
 mags-visualization --help
 ```
 
-### Basic example
+### Show help for a specific plot
+```bash
+mags-visualization sample-heatmap --help
+mags-visualization drep-cluster --help
+```
+
+### Example: sample heatmap
 ```bash
 
-mags-visualilzation \
+mags-visualilzation sample-heatmap \
   --coverm test-data/coverm.tsv \
-  --checkm test-data/checkm.tsv \
-  --checkm2 test-data/checkm2.tsv \
   --gtdb test-data/gtdb.tsv \
-  --drep test-data/drep.csv \
-  -o new-test-plots
+  --output out/sample-heatmap
 ```
 
 ### Example for test-data
 
 ```bash
 
-mags-visualization \
+mags-visualization all \
   --coverm test-data/coverm.tsv \
   --checkm test-data/checkm.tsv \
   --checkm2 test-data/checkm2.tsv \
@@ -222,6 +275,9 @@ To show in the heatmap more than one metadata column:
 ```bash
 --meta_cols weather temp ground # example columns
 ```
+
+
+## The following options are only available for the corresponding subcommands (e.g. `sample-heatmap`, `bakta-annotation`, `assembly-quality`)
 
 ## Heatmap Options
 ### Plot features

--- a/mags_visualization/drep_cluster_plot.py
+++ b/mags_visualization/drep_cluster_plot.py
@@ -299,13 +299,13 @@ def drep_cluster_plot(drep_df: pd.DataFrame, gtdb_df: pd.DataFrame, output_path:
 
     if rep_quality_available:
         # [sample names | bars | spacer | tax... | spacer | heatmap]
-        width_ratios = [0.10, 2, 0.02] + [tax_levels_space] * n_tax + [0.04, 0.4]
+        width_ratios = [0.03, 2, 0.02] + [tax_levels_space] * n_tax + [0.04, 0.4]
         gs = gridspec.GridSpec(
             1,
             len(width_ratios),
             figure=fig,
             width_ratios=width_ratios,
-            wspace=0.08,
+            wspace=0.04,
         )
         ax_samples = fig.add_subplot(gs[0, 0])
         ax_bars = fig.add_subplot(gs[0, 1])
@@ -381,9 +381,15 @@ def drep_cluster_plot(drep_df: pd.DataFrame, gtdb_df: pd.DataFrame, output_path:
     ax_samples.set_xlim(0, 1)
     ax_samples.set_ylim(-0.5, len(cluster_data) - 0.5)
     ax_samples.set_yticks(y_pos)
-    ax_samples.set_yticklabels(cluster_data['representative_display'].values, fontsize=8)
+    ax_samples.set_yticklabels(cluster_data['representative_display'].values, fontsize=8, ha='right')
+    ax_samples.tick_params(
+        axis="y",
+        which="both",
+        length=10,
+        width=0.4,
+        pad=4
+    )
     ax_samples.set_xticks([])
-    ax_samples.invert_xaxis()
 
     for spine in ax_samples.spines.values():
         spine.set_visible(False)

--- a/mags_visualization/main.py
+++ b/mags_visualization/main.py
@@ -1,23 +1,22 @@
-from json import load
 import pandas as pd
 import numpy as np
 import argparse
 import time
 import os
-import csv
 from .version import __version__
 from .sanky_taxa import generate_taxa_sanky,taxa_sanky_rank
 from .comp_conta_plot import completeness_contamination_plot, rank_completeness_contamination_plot, metadata_completeness_contamination_plot
-from .species_level_plot import species_level_plot
-from .mag_heatmap import mag_detection_heatmap
 from .heatmap import mag_heatmap
-from .histogram_plots import create_n50_histogram, number_of_contigs, create_assambly_info_histo
-from .rank_dist_plot import rank_distribution_pie
-# from .scripts.amber_plots import binner_plot
 from .assembly_quality import assembly_quality_plot
 from .bakta_checkm2_plot import bakta_annotation_plot
-# from drep_taxa_plot import drep_taxa_plot
 from .drep_cluster_plot import drep_cluster_plot
+
+
+def positive_int(value):
+    ivalue = int(value)
+    if ivalue < 5:
+        raise argparse.ArgumentTypeError(f"{value} must be >= 5")
+    return ivalue
 
 
 def read_table(path, index_col=None, prefer_tsv=None):
@@ -53,465 +52,6 @@ def read_table(path, index_col=None, prefer_tsv=None):
     return df
 
 
-# ---- Argument parsing ---- #
-def positive_int(value):
-    ivalue = int(value)
-    if ivalue < 5:
-        raise argparse.ArgumentTypeError(f"{value} must be >= 5")
-    return ivalue
-
-def parse_arguments(argv=None):
-
-    parser = argparse.ArgumentParser(
-        prog="MAGs-visualization",
-        description="Visualize and analyse MAGs (Metagenome-Assembled Genomes).",
-        usage="mags-visualization [OPTIONS]",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-        add_help=True,
-    )
-
-    parser.add_argument(
-        '-v',
-        '-V',
-        '--version',
-        action='version',
-        version=__version__
-    )
-
-    # Input
-    parser.add_argument(
-        '--coverm',
-        help="Path to the CoverM files",
-        dest="coverm_path"
-    )
-
-    parser.add_argument(
-        '--checkm',
-        help="Path to the CheckM file",
-        dest="checkm_file",
-        default=None
-    )
-
-    parser.add_argument(
-        '--checkm2',
-        help="Path to the CheckM2 file",
-        dest="checkm2_file",
-        default=None
-    )
-
-    parser.add_argument(
-        '--gtdb',
-        help="Path to the GTDB file",
-        dest="gtdb_file",
-        default=None
-    )
-
-    parser.add_argument(
-        '--drep',
-        help='Path to the dRep file',
-        dest='drep_file',
-        default=None
-    )
-
-    parser.add_argument(
-        '--gtdb_bac',
-        help="Input GTDB bacteria result file",
-        dest='gtdb_bac_file',
-        default=None
-    )
-
-    parser.add_argument(
-        '--gtdb_ar',
-        help="Input GTDB archaea result file",
-        dest='gtdb_ar_file',
-        default=None
-    )
-
-    parser.add_argument(
-        '--amber',
-        help="Input CAMI amber result file for different plots",
-        dest="amber_file",
-        default=None
-    )
-
-    parser.add_argument(
-        '--quast',
-        help="'Path to QUAST table",
-        dest="quast_file",
-        default=None,
-    )
-
-    parser.add_argument(
-        '--bakta',
-        help='Path to Bakta annotation table',
-        dest='bakta_file',
-        default=None
-    )
-
-    parser.add_argument(
-        '--metadata',
-        help='Path to METADATA',
-        dest="metadata_file",
-        default=None,
-    )
-
-    # Output
-    parser.add_argument(
-        '-o',
-        '--output',
-        help="Path to the output folder to save the plots",
-        dest="output",
-        default=None
-    )
-
-    # Taxonomic rank
-    parser.add_argument(
-        '-r',
-        '--rank',
-        help="Select which rank should be used for the rank sanky",
-        choices=["domain", "phylum", "class", "order", "family", "genus", "species"],
-        default="phylum",
-    )
-
-    parser.add_argument(
-        '-n',
-        '--top_n_counts',
-        '--top_n',
-        help='For the rank distribution, only plot the top n. DEFAULT:30',
-        type=positive_int,
-        dest="n",
-        default=30
-    )
-
-    parser.add_argument(
-        '--test'
-    )
-
-    # Heatmap Layout Options
-    heatmap_layout = parser.add_argument_group('Heatmap Layout Options',
-                                                'Fine-tune the heatmap visualization layout')
-    
-    heatmap_layout.add_argument(
-        '--fig_height_per_row',
-        type=float,
-        default=0.50,
-        dest='fig_height_per_row',
-        help='Height per sample row in heatmap (default: 0.50). Increase for many samples (e.g., 0.55-0.60)'
-    )
-    
-    heatmap_layout.add_argument(
-        '--fig_base_height',
-        type=float,
-        default=2.5,
-        dest='fig_base_height',
-        help='Base height for top/bottom margins (default: 2.5). Decrease for less space above (e.g., 2.0)'
-    )
-    
-    heatmap_layout.add_argument(
-        '--top_bar_height',
-        type=float,
-        default=0.7,
-        dest='top_bar_height',
-        help='Relative height of top histogram (default: 0.7). Smaller = more compact (e.g., 0.5-0.6)'
-    )
-    
-    heatmap_layout.add_argument(
-        '--hspace',
-        type=float,
-        default=0.25,
-        dest='hspace',
-        help='Vertical spacing between top and heatmap (default: 0.20). Reduce if too much space (0.15)'
-    )
-    
-    heatmap_layout.add_argument(
-        '--heatmap_width',
-        type=float,
-        default=11.0,
-        dest='heatmap_width',
-        help='Width ratio of the heatmap (default: 11.0). Increase for larger heatmap (e.g., 13.0)'
-    )
-
-    heatmap_layout.add_argument(
-        '--max_col',
-        type=int,
-        default=10,
-        dest='max_col',
-        help="Max shown taxonomy names."
-    )
-    
-    heatmap_layout.add_argument(
-        '--meta_bar_thickness',
-        type=float,
-        default=0.8,
-        dest='meta_bar_thickness',
-        help='Thickness of metadata bars (default: 0.7). Smaller = more space between bars (e.g., 0.5-0.6)'
-    )
-    
-    heatmap_layout.add_argument(
-        '--title_y',
-        type=float,
-        default=0.95,
-        dest='title_y',
-        help='Vertical position of title, 0.9-1.0 (default: 0.95). Lower = more space from top'
-    )
-    
-    heatmap_layout.add_argument(
-        '--heatmap_preset',
-        choices=['default', 'compact', 'spacious', 'many_samples', 'few_samples', 'focus_heatmap'],
-        default='default',
-        dest='heatmap_preset',
-        help='Use a predefined layout preset for common scenarios'
-    )
-
-    heatmap_layout.add_argument(
-        '--spacer_legend',
-        type=float,
-        default=0.3,
-        dest='spacer_legend',
-        help='Spacer between Legend and meta_bars.'
-    )
-
-    heatmap_layout.add_argument(
-        '--spacer_meta',
-        type=float,
-        default=2.0,
-        dest='spacer_meta',
-        help='Spacer between Meta_bars and Heatmap.'
-    )
-
-    heatmap_layout.add_argument(
-        '--spacer_heatmap',
-        type=float,
-        default=0.10,
-        dest='spacer_heatmap',
-        help='Spacer between Heatmap and histogram.'
-    )
-
-    heatmap_layout.add_argument(
-        '--legend',
-        type=float,
-        default=2.5,
-        dest='legend',
-        help='Legend width'
-    )
-
-    heatmap_layout.add_argument(
-        '--meta_bar_add',
-        type=float,
-        default=1.5,
-        dest='meta_bar_add',
-        help='Adding width to meta_bars'
-    )
-
-    heatmap_layout.add_argument(
-        '--top_bar_spacer',
-        type=float,
-        default=0.0,
-        dest='top_bar_spacer',
-        help='Space between top histogram title.'
-    )
-
-    heatmap_layout.add_argument(
-        '--no_log',
-        action="store_true",
-        help="Disable log10 for MAGs/rank bar plot."
-    )
-
-    # drep
-    parser.add_argument(
-        '--tax_levels_space',
-        type=float,
-        default=0.3,
-        dest='tax_levels_space',
-        help='Space for tax_levels columns in drep_cluster_plot.'
-    )
-
-    # Plot arguments and styles
-    parser.add_argument(
-        '--quality',
-        action="store_true",
-        help="Create plots colored by quality catergories"
-    )
-
-    parser.add_argument(
-        '--tax',
-        action="store_true",
-        help="Create plots colored by taxonomy"
-    )
-
-    parser.add_argument(
-        '--fig_size',
-        nargs=2,
-        type=float,
-        metavar=('WIDTH', 'HEIGHT'),
-        help="Figure size in inches for plots",
-        dest='fig_size'
-    )
-
-    parser.add_argument(
-        '--tax_level',
-        help="GTDB rank used for taxonomy-colored plots",
-        choices=["domain", "phylum", "class", "order", "family", "genus", "species"],
-        dest="tax_level"
-    )
-
-    parser.add_argument(
-        '--tax_levels',
-        nargs='+',
-        choices=["domain", "phylum", "class", "order", "family", "genus", "species"],
-        default=["phylum", "genus"],
-        help="GTDB taxonomy levels to show in dRep cluster plot"
-    )
-
-
-    parser.add_argument(
-        '--format',
-        help="Output image format for plots",
-        choices=["png", "pdf", "svg"],
-        default="png",
-        dest="format"
-    )
-
-    # Metadata options
-    parser.add_argument(
-        '--meta_col',
-        help="Metadata-Column to color by (e.g. 'weather, 'temperatur')",
-        dest="meta_col",
-        default=None
-    )
-
-    parser.add_argument(
-        '--meta_cols', 
-        nargs='+', 
-        help='List of metadata columns'
-        )
-
-    parser.add_argument(
-        '--meta_bin_width',
-        help='Bin-Width for numeric metadata',
-        dest='meta_bin_width',
-        type=float,
-        default=5.0
-    )
-
-    # Quast columns
-    parser.add_argument(
-        '--column_choice',
-        nargs='+',
-        metavar='METRIC',
-        help=("QUAST metrics to plot in the assembly quality dashboard. "
-            "Use the exact QUAST names, e.g. "
-            "\"N50\" \"GC\" \"# contigs\" \"Total length (>= 0 bp)\""
-        )
-    )
-
-    parser.add_argument(
-        '--color_by',
-        choices=['quality', 'tax', 'meta'],
-        help=(
-            "How to color points in the assembly quality plots: "
-            "'quality' = High/Medium/Low quality, "
-            "'tax' = taxonomy (uses GTDB) "
-            "'meta' = metadata. "
-            "If omitted, points are colored by completeness bins."
-        )
-    )
-
-    # Bakta metric
-    parser.add_argument(
-        '--bakta_metrics',
-        nargs='+',
-        metavar='METRIC',
-        default=None,
-        help="Use the exact BAKTA names ('CDSs', 'hypotheticals'...)"
-    )
-
-    parser.add_argument(
-        "--ratio",
-        action="store_true",
-        help="Plot with feature/cds ratios in bakta plot"
-    )
-
-    parser.print_usage = parser.print_help
-
-    args = parser.parse_args(argv)
-
-    return args
-
-# ---- Data loading ---- #
-def load_dfs(coverm, checkm, checkm2, gtdb, drep, bakta=None, quast=None, metadata=None):
-    dfs = {}
-
-    # Required
-    dfs["checkm"]  = read_table(checkm,  index_col=0)
-    print(f"[INFO] checkm loaded:  {dfs['checkm'].shape}")
-
-    dfs["checkm2"] = read_table(checkm2, index_col=0)
-    print(f"[INFO] checkm2 loaded: {dfs['checkm2'].shape}")
-
-    dfs["drep"] = read_table(drep, index_col=None, prefer_tsv=False)
-    print(f"[INFO] drep loaded:   {dfs['drep'].shape}")
-
-
-    dfs["gtdb"] = read_table(gtdb, index_col=0, prefer_tsv=True)
-    print(f"[INFO] gtdb loaded:   {dfs['gtdb'].shape}")
-
-    if dfs["drep"] is not None:
-        cols = [c.strip() for c in dfs["drep"].columns.astype(str)]
-        dfs["drep"].columns = cols
-
-    # --- dRep: ensure genome column exists ---
-    if dfs["drep"] is not None:
-        dfs["drep"].columns = [str(c).strip() for c in dfs["drep"].columns]
-
-        if "genome" not in dfs["drep"].columns and "Genome" in dfs["drep"].columns:
-            dfs["drep"] = dfs["drep"].rename(columns={"Genome": "genome"})
-
-        if "genome" not in dfs["drep"].columns:
-            dfs["drep"] = dfs["drep"].reset_index().rename(columns={"index": "genome"})
-
-
-    # Optional: coverm 
-    coverm_dfs = {}
-    if coverm is None:
-        print("[INFO] No coverm provided.")
-    else:
-        if os.path.isdir(coverm):
-            files = [f for f in os.listdir(coverm) if not f.startswith(".")]
-            if not files:
-                print(f"[WARN] No files found in coverm directory: {coverm}")
-            for i, file in enumerate(sorted(files)):
-                path = os.path.join(coverm, file)
-                coverm_dfs[f"coverm_{i}"] = read_table(path, index_col=0)
-                print(f"[INFO] coverm_{i} loaded: {coverm_dfs[f'coverm_{i}'].shape}")
-        else:
-            coverm_dfs["coverm_0"] = read_table(coverm, index_col=0)
-            print(f"[INFO] coverm_0 loaded: {coverm_dfs['coverm_0'].shape}")
-
-    dfs["coverm"] = coverm_dfs
-
-    # Optional tables (only load + print if provided)
-    if bakta is not None:
-        dfs["bakta"] = read_table(bakta, index_col=0)
-        print(f"[INFO] bakta loaded:  {dfs['bakta'].shape}")
-
-    if quast is not None:
-        dfs["quast"] = read_table(quast, index_col=0)
-        print(f"[INFO] quast loaded:  {dfs['quast'].shape}")
-
-    if metadata is not None:
-        dfs["metadata"] = read_table(metadata, index_col=0)
-        print(f"[INFO] metadata loaded:{dfs['metadata'].shape}")
-    else:
-        print("[INFO] No metadata file provided.")
-
-    return dfs
-
-
-def load_single_df(file_path):
-    return read_table(file_path, index_col=0)
-
-    
 def merged_coverm(coverm_dfs):
     """
     Merge multiple coverm tables column wise.
@@ -531,180 +71,266 @@ def merged_coverm(coverm_dfs):
 
 
 def check_path(output_path):
+    if output_path is None:
+        raise SystemExit("[ERROR] --output is required.")
     if not os.path.exists(output_path):
         os.makedirs(output_path)
         print(f"[INFO] Created folder: {output_path}")
     else:
         print(f"[INFO] Folder already exists: {output_path}")
 
-# ---- Main ---- #
-def main(argv=None):
-    start_time = time.time()
-    args = parse_arguments(argv)
+# ---- Data loading ---- #
+def load_dfs(coverm, checkm, checkm2, gtdb, drep, bakta=None, quast=None, metadata=None):
+    """
+    Load only what is provided.
+    """
+    dfs = {}
 
+    # checkm
+    if checkm is not None:
+        dfs["checkm"] = read_table(checkm, index_col=0)
+        print(f"[INFO] checkm loaded:  {dfs['checkm'].shape}")
+    else:
+        dfs["checkm"] = None
+
+    # checkm2
+    if checkm2 is not None:
+        dfs["checkm2"] = read_table(checkm2, index_col=0)
+        print(f"[INFO] checkm2 loaded: {dfs['checkm2'].shape}")
+    else:
+        dfs["checkm2"] = None
+
+    # drep
+    if drep is not None:
+        dfs["drep"] = read_table(drep, index_col=None, prefer_tsv=False)
+        print(f"[INFO] drep loaded:   {dfs['drep'].shape}")
+
+        # dRep cleanup to ensure genome column exists
+        dfs["drep"].columns = [str(c).strip() for c in dfs["drep"].columns]
+        if "genome" not in dfs["drep"].columns and "Genome" in dfs["drep"].columns:
+            dfs["drep"] = dfs["drep"].rename(columns={"Genome": "genome"})
+        if "genome" not in dfs["drep"].columns:
+            dfs["drep"] = dfs["drep"].reset_index().rename(columns={"index": "genome"})
+    else:
+        dfs["drep"] = None
+
+    # gtdb
+    if gtdb is not None:
+        dfs["gtdb"] = read_table(gtdb, index_col=0, prefer_tsv=True)
+        print(f"[INFO] gtdb loaded:   {dfs['gtdb'].shape}")
+    else:
+        dfs["gtdb"] = None
+
+    # coverm (table or folder)
+    coverm_dfs = {}
+    if coverm is None:
+        print("[INFO] No coverm provided.")
+    else:
+        if os.path.isdir(coverm):
+            files = [f for f in os.listdir(coverm) if not f.startswith(".")]
+            if not files:
+                print(f"[WARN] No files found in coverm directory: {coverm}")
+            for i, file in enumerate(sorted(files)):
+                path = os.path.join(coverm, file)
+                coverm_dfs[f"coverm_{i}"] = read_table(path, index_col=0)
+                print(f"[INFO] coverm_{i} loaded: {coverm_dfs[f'coverm_{i}'].shape}")
+        else:
+            coverm_dfs["coverm_0"] = read_table(coverm, index_col=0)
+            print(f"[INFO] coverm_0 loaded: {coverm_dfs['coverm_0'].shape}")
+
+    dfs["coverm"] = coverm_dfs
+
+    # optional tables
+    dfs["bakta"] = read_table(bakta, index_col=0) if bakta is not None else None
+    if dfs["bakta"] is not None:
+        print(f"[INFO] bakta loaded:  {dfs['bakta'].shape}")
+
+    dfs["quast"] = read_table(quast, index_col=0) if quast is not None else None
+    if dfs["quast"] is not None:
+        print(f"[INFO] quast loaded:  {dfs['quast'].shape}")
+
+    dfs["metadata"] = read_table(metadata, index_col=0) if metadata is not None else None
+    if dfs["metadata"] is not None:
+        print(f"[INFO] metadata loaded:{dfs['metadata'].shape}")
+    else:
+        print("[INFO] No metadata file provided.")
+
+    return dfs
+
+# ---- Parser builder - subcommands ---- #
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog="mags-visualization",
+        description="Visualize and analyse MAGs (Metagenome-Assembled Genomes).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("-v", "-V", "--version", action="version", version=__version__)
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    tax_levels = ["domain", "phylum", "class", "order", "family", "genus", "species"]
+
+    # ---- sample-heatmap ----
+    p = sub.add_parser("sample-heatmap", help="Create the sample heatmap plot.")
+    p.add_argument("--coverm", required=True, dest="coverm_path")
+    p.add_argument("--gtdb", required=True, dest="gtdb_file")
+    p.add_argument("--metadata", dest="metadata_file", default=None)
+    p.add_argument("--meta_cols", nargs="+", default=None)
+    p.add_argument("--tax_level", choices=tax_levels, default="phylum")
+    p.add_argument("-o", "--output", required=True, dest="output")
+    p.add_argument("--format", choices=["png", "pdf", "svg"], default="png", dest="format")
+    p.add_argument("--meta_bin_width", type=float, default=5.0, dest="meta_bin_width")
+    p.add_argument("--max_col", type=int, default=10, dest="max_col")
+    p.add_argument("--no_log", action="store_true")
+
+    # layout options
+    layout = p.add_argument_group("Heatmap Layout Options")
+    layout.add_argument("--top_bar_height", type=float, default=0.7, dest="top_bar_height")
+    layout.add_argument("--hspace", type=float, default=0.25, dest="hspace")
+    layout.add_argument("--heatmap_width", type=float, default=11.0, dest="heatmap_width")
+    layout.add_argument("--spacer_legend", type=float, default=0.3, dest="spacer_legend")
+    layout.add_argument("--spacer_meta", type=float, default=2.0, dest="spacer_meta")
+    layout.add_argument("--spacer_heatmap", type=float, default=0.10, dest="spacer_heatmap")
+    layout.add_argument("--legend", type=float, default=2.5, dest="legend")
+    layout.add_argument("--meta_bar_add", type=float, default=1.5, dest="meta_bar_add")
+    layout.add_argument("--top_bar_spacer", type=float, default=0.0, dest="top_bar_spacer")
+
+    # ---- drep-cluster ----
+    p = sub.add_parser("drep-cluster", help="Create the dRep cluster plot.")
+    p.add_argument("--drep", required=True, dest="drep_file")
+    p.add_argument("--gtdb", required=True, dest="gtdb_file")
+    p.add_argument("--checkm2", dest="checkm2_file", default=None)
+    p.add_argument("--quast", dest="quast_file", default=None)
+    p.add_argument("--bakta", dest="bakta_file", default=None)
+    p.add_argument("--tax_levels", nargs="+", choices=tax_levels, default=["phylum", "genus"])
+    p.add_argument("--top_n", type=positive_int, default=30, dest="n")
+    p.add_argument("--tax_levels_space", type=float, default=0.3, dest="tax_levels_space")
+    p.add_argument("--fig_size", nargs=2, type=float, metavar=("WIDTH", "HEIGHT"), dest="fig_size")
+    p.add_argument("-o", "--output", required=True, dest="output")
+    p.add_argument("--format", choices=["png", "pdf", "svg"], default="png", dest="format")
+
+    # ---- comp-conta ----
+    p = sub.add_parser("comp-conta", help="Completeness/contamination plots.")
+    p.add_argument("--checkm", required=True, dest="checkm_file")
+    p.add_argument("--checkm2", required=True, dest="checkm2_file")
+    p.add_argument("--gtdb", dest="gtdb_file", default=None)
+    p.add_argument("--metadata", dest="metadata_file", default=None)
+    p.add_argument("--meta_col", dest="meta_col", default=None)
+    p.add_argument("--meta_bin_width", type=float, default=5.0, dest="meta_bin_width")
+    p.add_argument("--top_n", type=positive_int, default=30, dest="n")
+    p.add_argument("--mode", choices=["quality", "tax", "meta"], default="quality",
+                   help="quality = plain plots; tax = rank plot needs --gtdb; meta = metadata plot needs --metadata and --meta_col")
+    p.add_argument("--tax_level", choices=tax_levels, default="phylum", dest="tax_level")
+    p.add_argument("--fig_size", nargs=2, type=float, metavar=("WIDTH", "HEIGHT"), dest="fig_size")
+    p.add_argument("-o", "--output", required=True, dest="output")
+    p.add_argument("--format", choices=["png", "pdf", "svg"], default="png", dest="format")
+
+    # ---- taxa-sankey ----
+    p = sub.add_parser("taxa-sankey", help="Create GTDB taxa sankey plots.")
+    p.add_argument("--gtdb", required=True, dest="gtdb_file")
+    p.add_argument("--rank", choices=tax_levels, default="phylum", dest="rank")
+    p.add_argument("-o", "--output", required=True, dest="output")
+
+    # ---- assembly-quality ----
+    p = sub.add_parser("assembly-quality", help="Create assembly quality plots (QUAST).")
+    p.add_argument("--quast", required=True, dest="quast_file")
+    p.add_argument("--checkm2", required=True, dest="checkm2_file")
+    p.add_argument("--gtdb", dest="gtdb_file", default=None)
+    p.add_argument("--metadata", dest="metadata_file", default=None)
+    p.add_argument("--meta_col", dest="meta_col", default=None)
+    p.add_argument("--tax_level", choices=tax_levels, default="phylum", dest="tax_level")
+    p.add_argument("--column_choice", nargs="+", metavar="METRIC", dest="column_choice")
+    p.add_argument("--color_by", choices=["quality", "tax", "meta"], dest="color_by")
+    p.add_argument("--fig_size", nargs=2, type=float, metavar=("WIDTH", "HEIGHT"), dest="fig_size")
+    p.add_argument("-o", "--output", required=True, dest="output")
+    p.add_argument("--format", choices=["png", "pdf", "svg"], default="png", dest="format")
+
+    # ---- bakta-annotation ----
+    p = sub.add_parser("bakta-annotation", help="Create Bakta annotation plots.")
+    p.add_argument("--bakta", required=True, dest="bakta_file")
+    p.add_argument("--checkm2", required=True, dest="checkm2_file")
+    p.add_argument("--gtdb", dest="gtdb_file", default=None)
+    p.add_argument("--metadata", dest="metadata_file", default=None)
+    p.add_argument("--meta_col", dest="meta_col", default=None)
+    p.add_argument("--tax_level", choices=tax_levels, default="phylum", dest="tax_level")
+    p.add_argument("--color_by", choices=["quality", "tax", "meta"], dest="color_by")
+    p.add_argument("--bakta_metrics", nargs="+", metavar="METRIC", default=None, dest="bakta_metrics")
+    p.add_argument("--ratio", action="store_true", dest="ratio")
+    p.add_argument("-o", "--output", required=True, dest="output")
+    p.add_argument("--format", choices=["png", "pdf", "svg"], default="png", dest="format")
+
+    # ---- all (optional) ----
+    p = sub.add_parser("all", help="Run all plots (legacy behaviour).")
+    p.add_argument("--coverm", dest="coverm_path", default=None)
+    p.add_argument("--checkm", dest="checkm_file", default=None)
+    p.add_argument("--checkm2", dest="checkm2_file", default=None)
+    p.add_argument("--gtdb", dest="gtdb_file", default=None)
+    p.add_argument("--drep", dest="drep_file", default=None)
+    p.add_argument("--quast", dest="quast_file", default=None)
+    p.add_argument("--bakta", dest="bakta_file", default=None)
+    p.add_argument("--metadata", dest="metadata_file", default=None)
+    p.add_argument("--rank", choices=tax_levels, default="phylum", dest="rank")
+    p.add_argument("--tax_level", choices=tax_levels, default=None, dest="tax_level")
+    p.add_argument("--tax_levels", nargs="+", choices=tax_levels, default=["phylum", "genus"])
+    p.add_argument("--top_n", type=positive_int, default=30, dest="n")
+    p.add_argument("--quality", action="store_true")
+    p.add_argument("--tax", action="store_true")
+    p.add_argument("--meta_col", dest="meta_col", default=None)
+    p.add_argument("--meta_cols", nargs="+", default=None)
+    p.add_argument("--meta_bin_width", type=float, default=5.0, dest="meta_bin_width")
+    p.add_argument("--column_choice", nargs="+", metavar="METRIC", dest="column_choice")
+    p.add_argument("--color_by", choices=["quality", "tax", "meta"], dest="color_by")
+    p.add_argument("--bakta_metrics", nargs="+", metavar="METRIC", default=None, dest="bakta_metrics")
+    p.add_argument("--ratio", action="store_true", dest="ratio")
+    p.add_argument("--tax_levels_space", type=float, default=0.3, dest="tax_levels_space")
+    p.add_argument("--fig_size", nargs=2, type=float, metavar=("WIDTH", "HEIGHT"), dest="fig_size")
+    p.add_argument("-o", "--output", required=True, dest="output")
+    p.add_argument("--format", choices=["png", "pdf", "svg"], default="png", dest="format")
+    # heatmap layout subset
+    p.add_argument("--top_bar_height", type=float, default=0.7, dest="top_bar_height")
+    p.add_argument("--hspace", type=float, default=0.25, dest="hspace")
+    p.add_argument("--heatmap_width", type=float, default=11.0, dest="heatmap_width")
+    p.add_argument("--spacer_legend", type=float, default=0.3, dest="spacer_legend")
+    p.add_argument("--spacer_meta", type=float, default=2.0, dest="spacer_meta")
+    p.add_argument("--spacer_heatmap", type=float, default=0.10, dest="spacer_heatmap")
+    p.add_argument("--legend", type=float, default=2.5, dest="legend")
+    p.add_argument("--meta_bar_add", type=float, default=1.5, dest="meta_bar_add")
+    p.add_argument("--top_bar_spacer", type=float, default=0.0, dest="top_bar_spacer")
+    p.add_argument("--max_col", type=int, default=10, dest="max_col")
+    p.add_argument("--no_log", action="store_true")
+
+    return parser
+
+
+def parse_arguments(argv=None):
+    return build_parser().parse_args(argv)
+
+# ---- Subcommand implementation ---- #
+def _fig_size_tuple(args):
+    return tuple(args.fig_size) if getattr(args, "fig_size", None) is not None else None
+
+
+def run_sample_heatmap(args):
     dfs = load_dfs(
-        args.coverm_path,
-        args.checkm_file,
-        args.checkm2_file,
-        args.gtdb_file,
-        args.drep_file,
-        bakta=args.bakta_file,
-        quast=args.quast_file,
+        coverm=args.coverm_path,
+        checkm=None,
+        checkm2=None,
+        gtdb=args.gtdb_file,
+        drep=None,
         metadata=args.metadata_file,
     )
-
-    dfs['coverm'] = merged_coverm(dfs['coverm'])
+    dfs["coverm"] = merged_coverm(dfs["coverm"])
     check_path(args.output)
 
-    # ---- Figure size ----
-    if args.fig_size is not None:
-        comp_fig_size = tuple(args.fig_size)
-    else:
-        comp_fig_size = None
-
-    # ---- Taxonomic rank for various plots (heatmap, assembly_quality...)
-    if args.tax_level is not None:
-        tax_rank = args.tax_level
-    elif args.rank is not None:
-        tax_rank = args.rank
-    else:
-        tax_rank = "phylum"
-
-    # same
-    if args.tax_level is not None:
-        aq_tax_rank = args.tax_level
-    elif args.rank is not None:
-        aq_tax_rank = args.rank
-    else:
-        aq_tax_rank = "phylum"
-
-
-    # ---- Batka metric selection ----
-    if args.bakta_metrics:
-        user_metrics = [m.strip().lower() for m in args.bakta_metrics]
-
-        bakta_metric_map = {
-            "cds": ("CDS", "cdss"),
-            "hypotheticals": ("Hypotheticals", "hypotheticals"),
-            "rrnas": ("rRNAs", "rrnas"),
-            "trnas": ("tRNAs", "trnas"),
-            "crispr": ("CRISPR", "crispr arrays"),
-            "pseudogenes": ("Pseudogenes", "pseudogenes"),
-        }
-
-        metrics_dict = {}
-        for m in user_metrics:
-            if m in bakta_metric_map:
-                disp, col = bakta_metric_map[m]
-                metrics_dict[disp] = col
-
-        if not metrics_dict:
-            print(
-                "[WARN] None of the requested Bakta metrics matched. "
-                "Falling back to default metrics (CDS, Hypotheticals, rRNAs, tRNAs)."
-            )
-            metrics_dict = None
-    else:
-        metrics_dict = None
-
-    bakta_ratio_flag = args.ratio
-
-    # ---- Sankey plots ----
-    generate_taxa_sanky(dfs['gtdb'], args.output, args.rank)
-    taxa_sanky_rank(dfs['gtdb'], args.output, args.rank)
-
-    # Decide which comp_conta_plot to run
-    run_quality = args.quality or (not args.quality and not args.tax)
-    run_tax     = args.tax or (not args.quality and not args.tax)
-
-    # ---- Completeness-Contamination Plots ----
-    # ---- Quality completeness/contamination plots ----
-    if run_quality:
-        completeness_contamination_plot(
-            dfs['checkm'],
-            args.output,
-            tag="checkm",
-            title="CheckM: Completeness vs Contamination",
-            fig_size=comp_fig_size if comp_fig_size is not None else (9, 8),
-            fmt=args.format
-        )
-        completeness_contamination_plot(
-            dfs['checkm2'],
-            args.output,
-            tag="checkm2",
-            title="CheckM2: Completeness vs Contamination",
-            fig_size=comp_fig_size if comp_fig_size is not None else (9, 8),
-            fmt=args.format
-        )
-    
-    # ---- Taxonomic completeness/contamination plots ----
-    if run_tax and args.gtdb_file is not None:
-        print("[RUN] Rank plot (using single GTDB table for both ar/bac) ...")
-        rank_completeness_contamination_plot(
-            dfs["checkm"],
-            dfs["checkm2"],
-            dfs["gtdb"],
-            tax_rank,
-            args.output,
-            args.n,
-            fig_size=comp_fig_size if comp_fig_size is not None else (10, 8),
-            fmt=args.format
-        )
-    
-    # --- Metadata completeness/contamination plots ---
-    if args.metadata_file is not None and "metadata" in dfs and args.meta_col is not None:
-        if args.meta_col not in dfs["metadata"].columns:
-            print(f"[WARN] Metadata column '{args.meta_col}' not found in metadata table. "
-                  f"Available columns: {list(dfs['metadata'].columns)}")
-        else:
-            print(f"[RUN] Metadata plot colored by '{args.meta_col}' ...")
-            metadata_completeness_contamination_plot(
-                dfs["checkm"],
-                dfs["checkm2"],
-                dfs["metadata"],
-                meta_col=args.meta_col,
-                output_path=args.output,
-                fig_size=comp_fig_size if comp_fig_size is not None else (10, 8),
-                fmt=args.format,
-                bin_width=args.meta_bin_width,
-                top_n=args.n
-            )
-    else:
-        if args.meta_col is not None and args.metadata_file is None:
-            print("[WARN] --meta_col set but no --metadata file was given."
-                  "→ skipping metadata-based plots.")
-
-    # drep and heatmap
-    # species_level_plot(dfs['drep'], args.output)
-    
-
-    # ---- dRep cluster plot ----
-    drep_cluster_plot(
-        dfs["drep"],
-        dfs["gtdb"],
-        args.output,
-        tax_levels=args.tax_levels,
-        top_n=args.n,
-        fig_size=comp_fig_size,
-        fmt=args.format,
-        tax_levels_space=args.tax_levels_space,
-        checkm2_df=dfs.get("checkm2"),
-        quast_df=dfs.get("quast"),
-        bakta_df=dfs.get("bakta"),
-    )
-
-    # mag_detection_heatmap(dfs["coverm"], args.output)
-    
     mag_heatmap(
         dfs["coverm"],
         dfs["gtdb"],
         args.output,
-        rank=tax_rank,
+        rank=args.tax_level,
         metadata_df=dfs.get("metadata"),
         meta_cols=args.meta_cols,
         meta_bin_width=args.meta_bin_width,
         fmt=args.format,
-        # Layout parameters
         top_bar_height=args.top_bar_height,
         hspace=args.hspace,
         heatmap_width=args.heatmap_width,
@@ -718,53 +344,309 @@ def main(argv=None):
         log_top=not args.no_log,
     )
 
-    # ---- Assembly histograms from checkm2 ----
-    # create_n50_histogram(dfs['checkm2'], args.output)
-    # number_of_contigs(dfs["checkm2"], args.output)
-    # create_assambly_info_histo(dfs["checkm2"], args.output)
 
-    # ---- Quast-based plots ----
-    if "quast" in dfs:
-        print("[INFO] QUAST found → creating assembly quality plots.")
-        assembly_quality_plot(
-            dfs,
+def run_drep_cluster(args):
+    dfs = load_dfs(
+        coverm=None,
+        checkm=None,
+        checkm2=args.checkm2_file,
+        gtdb=args.gtdb_file,
+        drep=args.drep_file,
+        bakta=args.bakta_file,
+        quast=args.quast_file,
+        metadata=None,
+    )
+    check_path(args.output)
+
+    drep_cluster_plot(
+        dfs["drep"],
+        dfs["gtdb"],
+        args.output,
+        tax_levels=args.tax_levels,
+        top_n=args.n,
+        fig_size=_fig_size_tuple(args),
+        fmt=args.format,
+        tax_levels_space=args.tax_levels_space,
+        checkm2_df=dfs.get("checkm2"),
+        quast_df=dfs.get("quast"),
+        bakta_df=dfs.get("bakta"),
+    )
+
+
+def run_comp_conta(args):
+    dfs = load_dfs(
+        coverm=None,
+        checkm=args.checkm_file,
+        checkm2=args.checkm2_file,
+        gtdb=args.gtdb_file,
+        drep=None,
+        metadata=args.metadata_file,
+    )
+    check_path(args.output)
+
+    fig_size = _fig_size_tuple(args) or (9, 8)
+
+    if args.mode == "quality":
+        completeness_contamination_plot(dfs["checkm"], args.output, tag="checkm",
+                                        title="CheckM: Completeness vs Contamination",
+                                        fig_size=fig_size, fmt=args.format)
+        completeness_contamination_plot(dfs["checkm2"], args.output, tag="checkm2",
+                                        title="CheckM2: Completeness vs Contamination",
+                                        fig_size=fig_size, fmt=args.format)
+        return
+
+    if args.mode == "tax":
+        if dfs["gtdb"] is None:
+            raise SystemExit("[ERROR] comp-conta --mode tax requires --gtdb")
+        rank_completeness_contamination_plot(
+            dfs["checkm"],
+            dfs["checkm2"],
+            dfs["gtdb"],
+            args.tax_level,
             args.output,
-            metrics=args.column_choice, 
+            args.n,
+            fig_size=_fig_size_tuple(args) or (10, 8),
+            fmt=args.format,
+        )
+        return
+
+    if args.mode == "meta":
+        if dfs["metadata"] is None or args.meta_col is None:
+            raise SystemExit("[ERROR] comp-conta --mode meta requires --metadata and --meta_col")
+        if args.meta_col not in dfs["metadata"].columns:
+            raise SystemExit(f"[ERROR] meta_col '{args.meta_col}' not found. Available: {list(dfs['metadata'].columns)}")
+        metadata_completeness_contamination_plot(
+            dfs["checkm"],
+            dfs["checkm2"],
+            dfs["metadata"],
+            meta_col=args.meta_col,
+            output_path=args.output,
+            fig_size=_fig_size_tuple(args) or (10, 8),
+            fmt=args.format,
+            bin_width=args.meta_bin_width,
+            top_n=args.n,
+        )
+        return
+
+    raise SystemExit(f"[ERROR] Unknown comp-conta mode: {args.mode}")
+
+
+def run_taxa_sankey(args):
+    dfs = load_dfs(
+        coverm=None,
+        checkm=None,
+        checkm2=None,
+        gtdb=args.gtdb_file,
+        drep=None,
+        metadata=None,
+    )
+    check_path(args.output)
+    generate_taxa_sanky(dfs["gtdb"], args.output, args.rank)
+    taxa_sanky_rank(dfs["gtdb"], args.output, args.rank)
+
+
+def run_assembly_quality(args):
+    dfs = load_dfs(
+        coverm=None,
+        checkm=None,
+        checkm2=args.checkm2_file,
+        gtdb=args.gtdb_file,
+        drep=None,
+        quast=args.quast_file,
+        metadata=args.metadata_file,
+    )
+    check_path(args.output)
+    assembly_quality_plot(
+        dfs,
+        args.output,
+        metrics=args.column_choice,
+        color_by=args.color_by,
+        tax_rank=args.tax_level,
+        meta_col=args.meta_col,
+        fig_size=_fig_size_tuple(args) or (5, 5),
+        fmt=args.format,
+    )
+
+
+def _bakta_metrics_dict(args):
+    if not args.bakta_metrics:
+        return None
+
+    user_metrics = [m.strip().lower() for m in args.bakta_metrics]
+    bakta_metric_map = {
+        "cds": ("CDS", "cdss"),
+        "hypotheticals": ("Hypotheticals", "hypotheticals"),
+        "rrnas": ("rRNAs", "rrnas"),
+        "trnas": ("tRNAs", "trnas"),
+        "crispr": ("CRISPR", "crispr arrays"),
+        "pseudogenes": ("Pseudogenes", "pseudogenes"),
+    }
+
+    metrics_dict = {}
+    for m in user_metrics:
+        if m in bakta_metric_map:
+            disp, col = bakta_metric_map[m]
+            metrics_dict[disp] = col
+
+    return metrics_dict or None
+
+
+def run_bakta_annotation(args):
+    dfs = load_dfs(
+        coverm=None,
+        checkm=None,
+        checkm2=args.checkm2_file,
+        gtdb=args.gtdb_file,
+        drep=None,
+        bakta=args.bakta_file,
+        metadata=args.metadata_file,
+    )
+    check_path(args.output)
+
+    bakta_annotation_plot(
+        dfs,
+        args.output,
+        metrics=_bakta_metrics_dict(args),
+        color_by=args.color_by,
+        tax_rank=args.tax_level,
+        meta_col=args.meta_col,
+        plot_ratio=args.ratio,
+    )
+
+
+def run_all(args):
+    """
+    Runs all what it can based on provided inputs.
+    """
+    dfs = load_dfs(
+        args.coverm_path,
+        args.checkm_file,
+        args.checkm2_file,
+        args.gtdb_file,
+        args.drep_file,
+        bakta=args.bakta_file,
+        quast=args.quast_file,
+        metadata=args.metadata_file,
+    )
+    check_path(args.output)
+
+    if dfs.get("coverm"):
+        dfs["coverm"] = merged_coverm(dfs["coverm"])
+
+    comp_fig_size = _fig_size_tuple(args)
+
+    tax_rank = args.tax_level or args.rank or "phylum"
+    aq_tax_rank = args.tax_level or args.rank or "phylum"
+
+    # sankey
+    if dfs["gtdb"] is not None:
+        generate_taxa_sanky(dfs["gtdb"], args.output, args.rank)
+        taxa_sanky_rank(dfs["gtdb"], args.output, args.rank)
+
+    # comp/conta
+    run_quality = args.quality or (not args.quality and not args.tax)
+    run_tax = args.tax or (not args.quality and not args.tax)
+
+    if run_quality and dfs["checkm"] is not None:
+        completeness_contamination_plot(
+            dfs["checkm"], args.output, tag="checkm",
+            title="CheckM: Completeness vs Contamination",
+            fig_size=comp_fig_size or (9, 8), fmt=args.format
+        )
+    if run_quality and dfs["checkm2"] is not None:
+        completeness_contamination_plot(
+            dfs["checkm2"], args.output, tag="checkm2",
+            title="CheckM2: Completeness vs Contamination",
+            fig_size=comp_fig_size or (9, 8), fmt=args.format
+        )
+
+    if run_tax and dfs["gtdb"] is not None and dfs["checkm"] is not None and dfs["checkm2"] is not None:
+        rank_completeness_contamination_plot(
+            dfs["checkm"], dfs["checkm2"], dfs["gtdb"], tax_rank,
+            args.output, args.n,
+            fig_size=comp_fig_size or (10, 8), fmt=args.format
+        )
+
+    if dfs.get("drep") is not None and dfs.get("gtdb") is not None:
+        drep_cluster_plot(
+            dfs["drep"], dfs["gtdb"], args.output,
+            tax_levels=args.tax_levels, top_n=args.n,
+            fig_size=comp_fig_size, fmt=args.format,
+            tax_levels_space=args.tax_levels_space,
+            checkm2_df=dfs.get("checkm2"),
+            quast_df=dfs.get("quast"),
+            bakta_df=dfs.get("bakta"),
+        )
+
+    if dfs.get("coverm") is not None and dfs.get("gtdb") is not None:
+        mag_heatmap(
+            dfs["coverm"], dfs["gtdb"], args.output,
+            rank=tax_rank,
+            metadata_df=dfs.get("metadata"),
+            meta_cols=args.meta_cols,
+            meta_bin_width=args.meta_bin_width,
+            fmt=args.format,
+            top_bar_height=args.top_bar_height,
+            hspace=args.hspace,
+            heatmap_width=args.heatmap_width,
+            spacer_legend=args.spacer_legend,
+            spacer_meta=args.spacer_meta,
+            spacer_heatmap=args.spacer_heatmap,
+            legend=args.legend,
+            meta_bar_add=args.meta_bar_add,
+            top_bar_spacer=args.top_bar_spacer,
+            max_col=args.max_col,
+            log_top=not args.no_log,
+        )
+
+    if dfs.get("quast") is not None and dfs.get("checkm2") is not None:
+        assembly_quality_plot(
+            dfs, args.output,
+            metrics=args.column_choice,
             color_by=args.color_by,
             tax_rank=aq_tax_rank,
             meta_col=args.meta_col,
-            fig_size=comp_fig_size if comp_fig_size is not None else (5, 5),
+            fig_size=comp_fig_size or (5, 5),
             fmt=args.format,
         )
+
+    if dfs.get("bakta") is not None and dfs.get("checkm2") is not None:
+        bakta_annotation_plot(
+            dfs, args.output,
+            metrics=_bakta_metrics_dict(args),
+            color_by=args.color_by,
+            tax_rank=aq_tax_rank,
+            meta_col=args.meta_col,
+            plot_ratio=args.ratio,
+        )
+
+
+# ---- Main ---- #
+def main(argv=None):
+    start_time = time.time()
+    args = parse_arguments(argv)
+
+    if args.command == "sample-heatmap":
+        run_sample_heatmap(args)
+    elif args.command == "drep-cluster":
+        run_drep_cluster(args)
+    elif args.command == "comp-conta":
+        run_comp_conta(args)
+    elif args.command == "taxa-sankey":
+        run_taxa_sankey(args)
+    elif args.command == "assembly-quality":
+        run_assembly_quality(args)
+    elif args.command == "bakta-annotation":
+        run_bakta_annotation(args)
+    elif args.command == "all":
+        run_all(args)
     else:
-        print("[WARN] No Quast file loaded → skipping assembly quality plots.")
-
-    # ---- Rank distribution pie plot ----
-    # rank_distribution_pie(dfs["gtdb"], args.output, args.rank, args.n)
-
-    # ---- Bakta-based plots ----
-    if "bakta" in dfs:
-        print("[INFO] Bakta found → creating Bakta plots.")
-        bakta_annotation_plot(dfs,
-                                   args.output,
-                                   metrics=metrics_dict,
-                                   color_by=args.color_by,
-                                   tax_rank=aq_tax_rank,
-                                   meta_col=args.meta_col,
-                                   plot_ratio=args.ratio,
-                                   )
-    else:
-        print("[WARN] No Bakta file loaded → skipping Bakta plots.")
-
-   # ---- Amber plots ----
-    # if args.amber_file is not None:
-    #     binner_plot(load_single_df(args.amber_file), args.output)
-
+        raise SystemExit(f"[ERROR] Unknown command: {args.command}")
 
     end_time = time.time()
-    print(f'[INFO] Run time: {time.strftime("%H:%M:%S", time.gmtime(end_time - start_time))}')
-
+    print(f"[INFO] Run time: {time.strftime('%H:%M:%S', time.gmtime(end_time - start_time))}")
     return 0
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/test-script.py
+++ b/scripts/test-script.py
@@ -23,6 +23,7 @@ def main() -> int:
         # sys.executable,
         # str(main_py),
         sys.executable, "-m", "mags_visualization.main",
+        "all",
 
         "--coverm", str(use_case_folder / "coverm.tsv"),
         "--checkm", str(use_case_folder / "checkm.tsv"),

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -1,53 +1,32 @@
 # Example use case
 All commands below assume that the command-line tool `mags-visualization`is installed and available in your environment.
 
+Each plot is generated using a dedicated **subcommand**.
+
 The working directory should be **MAGs-visualization/use-cases** 
 so that the example paths resolve correctly.
 
 If the command is not available, install the package first (['README.md'](../README.md))
 
 # Bash
-## Marine
-
-```bash
-use_case_folder="marine-use-case/data"
-
-mags-visualization \
-  --coverm "$use_case_folder/coverm.tsv" \
-  --checkm "$use_case_folder/checkm.tsv" \
-  --checkm2 "$use_case_folder/checkm2.tsv" \
-  --gtdb "$use_case_folder/gtdb.tsv" \
-  --drep "$use_case_folder/drep.csv" \
-  --quast "$use_case_folder/quast.tsv" \
-  --bakta "$use_case_folder/bakta.tsv" \
-  --color_by tax \
-  --tax_level genus \
-  --max_col 10 \
-  --top_n 30 \
-  -o test
-```
-
 ## Bee
 
 ```bash
 use_case_folder="bee-use-case/data"
+```
 
-mags-visualization \
+### Sample heatmap
+
+```bash
+mags-visualization sample-heatmap \
   --coverm "$use_case_folder/coverm.tsv" \
-  --checkm "$use_case_folder/checkm.tsv" \
-  --checkm2 "$use_case_folder/checkm2.tsv" \
   --gtdb "$use_case_folder/gtdb.tsv" \
-  --drep "$use_case_folder/drep.csv" \
-  --quast "$use_case_folder/quast.tsv" \
-  --bakta "$use_case_folder/bakta.tsv" \
   --metadata "$use_case_folder/metadata.tsv" \
   --meta_cols "Infection by Nosema ceranae" "Chronic exposure to neonicotinoid" "Treatment with probiotic" \
-  --color_by tax \
-  --tax_level phylum \
-  --top_n 30 \
-  --top_bar_spacer -0.5 \
+  --tax_level genus \
+  --top_bar_spacer -1.0 \
   --spacer_meta 2.5 \
-  -o test
+  --output out
 ```
 
 ```bash
@@ -55,28 +34,148 @@ mags-visualization \
 --top_bar_height 2.0
 ```
 
+### dRep cluster plot
+
+```bash
+mags-visualization drep-cluster \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --drep "$use_case_folder/drep.csv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --bakta "$use_case_folder/bakta.tsv" \
+  --quast "$use_case_folder/quast.tsv" \
+  --output out
+```
+
+### Completeness / Contamination
+
+```bash
+mags-visualization comp-conta \
+  --checkm "$use_case_folder/checkm.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --mode quality \
+  --output out
+```
+
+### Assembly quality (QUAST)
+
+```bash
+mags-visualization assembly-quality \
+  --quast "$use_case_folder/quast.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --color_by tax \
+  --tax_level phylum \
+  --output out
+```
+
+### Bakta annotation
+
+```bash
+mags-visualization bakta-annotation \
+  --bakta "$use_case_folder/bakta.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --output out
+```
+
+### Taxonomy Sankey plot
+
+```bash
+mags-visualization taxa-sankey \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --rank phylum \
+  --output out
+```
+
+## Marine
+
+```bash
+use_case_folder="marine-use-case/data"
+```
+
+### Sample heatmap
+
+```bash
+mags-visualization sample-heatmap \
+  --coverm "$use_case_folder/coverm.tsv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --tax_level genus \
+  --output out
+```
+
+### dRep cluster plot
+
+```bash
+mags-visualization drep-cluster \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --drep "$use_case_folder/drep.csv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --bakta "$use_case_folder/bakta.tsv" \
+  --quast "$use_case_folder/quast.tsv" \
+  --output out
+```
+
+### Completeness / Contamination
+
+```bash
+mags-visualization comp-conta \
+  --checkm "$use_case_folder/checkm.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --mode quality \
+  --output out
+```
+
+### Assembly quality (QUAST)
+
+```bash
+mags-visualization assembly-quality \
+  --quast "$use_case_folder/quast.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --color_by tax \
+  --tax_level phylum \
+  --output out
+```
+
+### Bakta annotation
+
+```bash
+mags-visualization bakta-annotation \
+  --bakta "$use_case_folder/bakta.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --output out
+```
+
+### Taxonomy Sankey plot
+
+```bash
+mags-visualization taxa-sankey \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --rank phylum \
+  --output out
+```
+
+
 ## Cloud
 
 ```bash
 use_case_folder="cloud-use-case/data"
+```
 
-mags-visualization \
+### Sample heatmap
+
+```bash
+mags-visualization sample-heatmap \
   --coverm "$use_case_folder/coverm.tsv" \
-  --checkm "$use_case_folder/checkm.tsv" \
-  --checkm2 "$use_case_folder/checkm2.tsv" \
   --gtdb "$use_case_folder/gtdb.tsv" \
-  --drep "$use_case_folder/drep.csv" \
-  --quast "$use_case_folder/quast.tsv" \
-  --bakta "$use_case_folder/bakta.tsv" \
   --metadata "$use_case_folder/metadata.tsv" \
   --meta_cols "Geographic origin of the air mass" "Condition" "Season" \
-  --color_by tax \
-  --tax_level phylum \
-  --top_n 30 \
+  --tax_level genus \
   --top_bar_spacer -0.5 \
   --no_log \
   --top_bar_height 3.5 \
-  -o test
+  --output out
 ```
 
 If without --no_log:
@@ -84,38 +183,135 @@ If without --no_log:
 --top_bar_height 1.4
 ```
 
+### dRep cluster plot
+
+```bash
+mags-visualization drep-cluster \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --drep "$use_case_folder/drep.csv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --bakta "$use_case_folder/bakta.tsv" \
+  --quast "$use_case_folder/quast.tsv" \
+  --output out
+```
+
+### Completeness / Contamination
+
+```bash
+mags-visualization comp-conta \
+  --checkm "$use_case_folder/checkm.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --mode quality \
+  --output out
+```
+
+### Assembly quality (QUAST)
+
+```bash
+mags-visualization assembly-quality \
+  --quast "$use_case_folder/quast.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --color_by tax \
+  --tax_level phylum \
+  --output out
+```
+
+### Bakta annotation
+
+```bash
+mags-visualization bakta-annotation \
+  --bakta "$use_case_folder/bakta.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --output out
+```
+
+### Taxonomy Sankey plot
+
+```bash
+mags-visualization taxa-sankey \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --rank phylum \
+  --output out
+```
+
 ## Termite
 
 ```bash
 use_case_folder="termite-use-case/data"
+```
 
-mags-visualization \
+### Sample heatmap
+
+```bash
+mags-visualization sample-heatmap \
   --coverm "$use_case_folder/coverm.tsv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --metadata "$use_case_folder/metadata.tsv" \
+  --meta_cols "Species" "Casts" "Colony" \
+  --tax_level genus \
+  --no_log \
+  --spacer_meta 4.5 \
+  --top_bar_height 1.5 \
+  --hspace 0.08 \
+  --output out
+```
+
+### dRep cluster plot
+
+```bash
+mags-visualization drep-cluster \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --drep "$use_case_folder/drep.csv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --quast "$use_case_folder/quast.tsv" \
+  --output out
+```
+
+### Completeness / Contamination
+
+```bash
+mags-visualization comp-conta \
   --checkm "$use_case_folder/checkm.tsv" \
   --checkm2 "$use_case_folder/checkm2.tsv" \
   --gtdb "$use_case_folder/gtdb.tsv" \
-  --drep "$use_case_folder/drep.csv" \
-  --quast "$use_case_folder/quast.tsv" \
-  --metadata "$use_case_folder/metadata.tsv" \
-  --meta_cols "Species" "Casts" "Colony" \
-  --color_by tax \
-  --tax_level genus \
-  --max_col 10 \
-  --top_n 30 \
-  --spacer_meta 4.0 \
-  --no_log \
-  -o test
+  --mode quality \
+  --output out
 ```
 
+### Assembly quality (QUAST)
+
+```bash
+mags-visualization assembly-quality \
+  --quast "$use_case_folder/quast.tsv" \
+  --checkm2 "$use_case_folder/checkm2.tsv" \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --color_by tax \
+  --tax_level genus \
+  --output out
+```
+
+### Taxonomy Sankey plot
+
+```bash
+mags-visualization taxa-sankey \
+  --gtdb "$use_case_folder/gtdb.tsv" \
+  --rank phylum \
+  --output out
+```
+
+
 # Powershell
-If you want to use powershell instead of bash, here are the examples.
+If you want to use powershell instead of bash, it's just a different syntax.
+In the following examples the **subcommand** "all" is used, which produces all plots.
 
 ## Marine
 
 ```powershell
 $use_case_folder = "marine-use-case\data"
 
-mags-visualization `
+mags-visualization all `
   --coverm "$use_case_folder\coverm.tsv" `
   --checkm "$use_case_folder\checkm.tsv" `
   --checkm2 "$use_case_folder\checkm2.tsv" `
@@ -135,7 +331,7 @@ mags-visualization `
 ```powershell
 $use_case_folder = "bee-use-case\data"
 
-mags-visualization `
+mags-visualization all `
   --coverm "$use_case_folder\coverm.tsv" `
   --checkm "$use_case_folder\checkm.tsv" `
   --checkm2 "$use_case_folder\checkm2.tsv" `
@@ -163,7 +359,7 @@ mags-visualization `
 ```powershell
 $use_case_folder = "cloud-use-case\data"
 
-mags-visualization `
+mags-visualization all `
   --coverm "$use_case_folder\coverm.tsv" `
   --checkm "$use_case_folder\checkm.tsv" `
   --checkm2 "$use_case_folder\checkm2.tsv" `
@@ -192,7 +388,7 @@ If without --no_log:
 ```powershell
 $use_case_folder = "termite-use-case\data"
 
-mags-visualization `
+mags-visualization all `
   --coverm "$use_case_folder\coverm.tsv" `
   --checkm "$use_case_folder\checkm.tsv" `
   --checkm2 "$use_case_folder\checkm2.tsv" `


### PR DESCRIPTION
This PR changes the command-line interface to use subcommands instead of a single command.

Each plot type can now be executed indepently.

The following subcommands were added:
- sample-heatmap
- drep-cluster
- comp-conta
- taxa-sankey
- assembly-quality
- bakta-annotation
- all

All subcommands were tested locally using the provided use-case datasets.

Updated main README.md to describe the new subcommand-based CLI.
Also updated use-cases/README.md with concrete examples for the new commands.